### PR TITLE
fix simulator_example bug, env_example performance issue

### DIFF
--- a/docs/simulators.md
+++ b/docs/simulators.md
@@ -40,7 +40,7 @@ def main():
 
     for _ in range(10):
         obj = YCBObject('003_cracker_box')
-        obj.load()
+        s.import_object(obj)
         obj.set_position_orientation(np.random.uniform(low=0, high=2, size=3), [0,0,0,1])
 
     for i in range(10000):

--- a/examples/demo/simulator_example.py
+++ b/examples/demo/simulator_example.py
@@ -20,7 +20,7 @@ def main():
 
     for _ in range(10):
         obj = YCBObject('003_cracker_box')
-        obj.load()
+        s.import_object(obj)
         obj.set_position_orientation(np.random.uniform(low=0, high=2, size=3), [0,0,0,1])
 
     for i in range(10000):

--- a/gibson2/core/physics/scene.py
+++ b/gibson2/core/physics/scene.py
@@ -147,7 +147,10 @@ class BuildingScene(Scene):
             visual_id = p.createVisualShape(p.GEOM_MESH,
                                             fileName=filename)
             texture_filename = get_texture_file(filename)
-            texture_id = p.loadTexture(texture_filename)
+            if texture_filename is not None:
+                texture_id = p.loadTexture(texture_filename)
+            else:
+                texture_id = -1
         else:
             visual_id = -1
             texture_id = -1
@@ -157,7 +160,8 @@ class BuildingScene(Scene):
         p.changeDynamics(self.mesh_body_id, -1, lateralFriction=1)
 
         if self.pybullet_load_texture:
-            p.changeVisualShape(self.mesh_body_id,
+            if texture_id != -1:
+                p.changeVisualShape(self.mesh_body_id,
                                 -1,
                                 textureUniqueId=texture_id)
 
@@ -171,10 +175,14 @@ class BuildingScene(Scene):
                 visual_id = p.createVisualShape(p.GEOM_MESH,
                                                 fileName=plane_name)
                 texture_filename = get_texture_file(plane_name)
-                texture_id = p.loadTexture(texture_filename)
+                if texture_filename is not None:
+                    texture_id = p.loadTexture(texture_filename)
+                else:
+                    texture_id = -1
                 floor_body_id = p.createMultiBody(baseCollisionShapeIndex=collision_id,
                                                   baseVisualShapeIndex=visual_id)
-                p.changeVisualShape(floor_body_id,
+                if texture_id != -1:
+                    p.changeVisualShape(floor_body_id,
                                     -1,
                                     textureUniqueId=texture_id)
                 floor_height = self.floors[f]

--- a/gibson2/core/simulator.py
+++ b/gibson2/core/simulator.py
@@ -20,7 +20,8 @@ class Simulator:
                  image_height=128,
                  vertical_fov=90,
                  device_idx=0,
-                 render_to_tensor=False):
+                 render_to_tensor=False,
+                 auto_sync=True):
         """
         Simulator class is a wrapper of physics simulator (pybullet) and MeshRenderer, it loads objects into
         both pybullet and also MeshRenderer and syncs the pose of objects and robot parts.
@@ -34,6 +35,8 @@ class Simulator:
         :param vertical_fov: vertical field of view of the camera image in degrees
         :param device_idx: GPU device index to run rendering on
         :param render_to_tensor: Render to GPU tensors
+        :param auto_sync: automatically sync object poses to gibson renderer, by default true,
+        disable it when you want to run multiple physics step but don't need to visualize each frame
         """
         # physics simulator
         self.gravity = gravity
@@ -47,6 +50,7 @@ class Simulator:
         self.device_idx = device_idx
         self.use_fisheye = use_fisheye
         self.render_to_tensor = render_to_tensor
+        self.auto_sync = auto_sync
         self.load()
 
     def set_timestep(self, timestep):
@@ -407,7 +411,8 @@ class Simulator:
         """
 
         p.stepSimulation()
-        self.sync()
+        if self.auto_sync:
+            self.sync()
 
     def sync(self):
         """

--- a/gibson2/envs/base_env.py
+++ b/gibson2/envs/base_env.py
@@ -41,7 +41,8 @@ class BaseEnv(gym.Env):
                                    image_width=self.config.get('image_width', 128),
                                    image_height=self.config.get('image_height', 128),
                                    vertical_fov=self.config.get('vertical_fov', 90),
-                                   device_idx=device_idx)
+                                   device_idx=device_idx,
+                                   auto_sync=False)
         self.simulator_loop = int(self.action_timestep / self.simulator.timestep)
         self.load()
 

--- a/gibson2/envs/locomotor_env.py
+++ b/gibson2/envs/locomotor_env.py
@@ -387,6 +387,8 @@ class NavigateEnv(BaseEnv):
         for _ in range(self.simulator_loop):
             self.simulator_step()
             collision_links.append(list(p.getContactPoints(bodyA=self.robots[0].robot_ids[0])))
+        self.simulator.sync()
+
         return self.filter_collision_links(collision_links)
 
     def filter_collision_links(self, collision_links):

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -1,6 +1,5 @@
 from gibson2.core.render.mesh_renderer.mesh_renderer_cpu import MeshRenderer
 import numpy as np
-import torch
 import os
 import matplotlib.pyplot as plt
 import gibson2


### PR DESCRIPTION
- in simulator_example it should be `s.import_object(obj)`
- added `auto_sync` parameter to `Simulator` class, allow only rendering key frames