### PR TITLE
Add turtlebot3

### DIFF
--- a/gibson2/core/physics/robot_locomotors.py
+++ b/gibson2/core/physics/robot_locomotors.py
@@ -444,6 +444,41 @@ class Turtlebot(LocomotorRobot):
         }
 
 
+class Turtlebot3(LocomotorRobot):
+    def __init__(self, config):
+        self.config = config
+        self.velocity = config.get("velocity", 0.5)
+        LocomotorRobot.__init__(self,
+                                "turtlebot3_description/turtlebot3_waffle_pi_for_open_manipulator.urdf",
+                                action_dim=2,
+                                scale=config.get("robot_scale", 1.0),
+                                is_discrete=config.get("is_discrete", False),
+                                control="velocity")
+
+    def set_up_continuous_action_space(self):
+        self.action_space = gym.spaces.Box(shape=(self.action_dim,),
+                                           low=-1.0,
+                                           high=1.0,
+                                           dtype=np.float32)
+        self.action_high = np.full(shape=self.action_dim, fill_value=self.velocity)
+        self.action_low = -self.action_high
+
+    def set_up_discrete_action_space(self):
+        self.action_list = [[self.velocity, self.velocity], [-self.velocity, -self.velocity],
+                            [self.velocity * 0.5, -self.velocity * 0.5],
+                            [-self.velocity * 0.5, self.velocity * 0.5], [0, 0]]
+        self.action_space = gym.spaces.Discrete(len(self.action_list))
+        self.setup_keys_to_action()
+
+    def setup_keys_to_action(self):
+        self.keys_to_action = {
+            (ord('w'),): 0,  # forward
+            (ord('s'),): 1,  # backward
+            (ord('d'),): 2,  # turn right
+            (ord('a'),): 3,  # turn left
+            (): 4  # stay still
+        }
+
 class Freight(LocomotorRobot):
     def __init__(self, config):
         self.config = config


### PR DESCRIPTION
Add turtlebot3 for Berkeley folks, to use it:

1) Download this zip file and put in `assets/models`, this is adapted from https://github.com/ROBOTIS-GIT/turtlebot3
[turtlebot3.zip](https://github.com/StanfordVL/iGibson/files/5248425/turtlebot3.zip)

2) Example usage (modified from `examples/demo/simulator_example.py`)

```python
from gibson2.core.physics.robot_locomotors import Turtlebot3
from gibson2.core.simulator import Simulator
from gibson2.core.physics.scene import BuildingScene
from gibson2.core.physics.interactive_objects import YCBObject
from gibson2.utils.utils import parse_config
import pybullet as p
import numpy as np
from gibson2.core.render.profiler import Profiler


def main():
    config = parse_config('../configs/turtlebot_demo.yaml')
    s = Simulator(mode='gui', image_width=512, image_height=512)
    scene = BuildingScene('Rs',
                          build_graph=True,
                          pybullet_load_texture=True)
    s.import_scene(scene)
    turtlebot = Turtlebot3(config)
    s.import_robot(turtlebot)

    for _ in range(10):
        obj = YCBObject('003_cracker_box')
        s.import_object(obj)
        obj.set_position_orientation(np.random.uniform(low=0, high=2, size=3), [0,0,0,1])

    for i in range(10000):
        with Profiler('Simulator step'):
            turtlebot.apply_action([-1,1])
            s.step()
            rgb = s.renderer.render_robot_cameras(modes=('rgb'))

    s.disconnect()


if __name__ == '__main__':
    main()
```