### PR TITLE
fix to avoid docker building error

### DIFF
--- a/docker/headless-gui/Dockerfile
+++ b/docker/headless-gui/Dockerfile
@@ -1,7 +1,7 @@
 FROM igibson/igibson:latest
 
 # add dummy display and remote GUI via x11VNC
-
+RUN DEBIAN_FRONTEND=noninteractive apt update
 RUN DEBIAN_FRONTEND=noninteractive apt install -y \
     xserver-xorg-video-dummy \
     xfce4 desktop-base \


### PR DESCRIPTION
Add `apt update` to avoid building error when executing 'apt install' caused by outdated source info.