### PR TITLE
Correctly pass scale to pybullet API

### DIFF
--- a/igibson/objects/shapenet_object.py
+++ b/igibson/objects/shapenet_object.py
@@ -37,7 +37,7 @@ class ShapeNetObject(StatefulObject):
         """
         Load the object into pybullet
         """
-        collision_id = p.createCollisionShape(p.GEOM_MESH, fileName=self.filename, meshScale=self.scale)
+        collision_id = p.createCollisionShape(p.GEOM_MESH, fileName=self.filename, meshScale=(self.scale,) * 3)
         body_id = p.createMultiBody(
             basePosition=self.pose["position"],
             baseOrientation=self.pose["orientation_quat"],

--- a/igibson/objects/ycb_object.py
+++ b/igibson/objects/ycb_object.py
@@ -19,8 +19,8 @@ class YCBObject(StatefulObject):
         self.scale = scale
 
     def _load(self, simulator):
-        collision_id = p.createCollisionShape(p.GEOM_MESH, fileName=self.collision_filename, meshScale=self.scale)
-        visual_id = p.createVisualShape(p.GEOM_MESH, fileName=self.visual_filename, meshScale=self.scale)
+        collision_id = p.createCollisionShape(p.GEOM_MESH, fileName=self.collision_filename, meshScale=(self.scale,) * 3)
+        visual_id = p.createVisualShape(p.GEOM_MESH, fileName=self.visual_filename, meshScale=(self.scale,) * 3)
 
         body_id = p.createMultiBody(
             baseCollisionShapeIndex=collision_id,


### PR DESCRIPTION
Currently, setting a scale different from 1 for YCB objects has no effect. This is because the scale is passed as scalar to the pybullet API (`createCollisionShape` and `createVisualShape`), instead of as a vector of length 3 (as mentioned in the [pybullet documentation](https://docs.google.com/document/d/10sXEhzFRSnvFcl3XxNGhnD4N2SedqwdAvK3dsihxVUA/edit#heading=h.q1gn7v6o58bf)). Unfortunately, pybullet seems to ignore the scale parameter silently if it is given in the wrong format.

This PR fixes the issue by passing the scale as an iterable of length 3. I updated this in the code for all of the above mentioned pybullet API calls that pass a scale.