### PR TITLE
Fix igibson-vnc Dockerfile by adding apt update before apt install

### DIFF
--- a/docker/igibson-vnc/Dockerfile
+++ b/docker/igibson-vnc/Dockerfile
@@ -2,7 +2,7 @@ FROM igibson/igibson:latest
 
 # add dummy display and remote GUI via x11VNC
 
-RUN DEBIAN_FRONTEND=noninteractive apt install -y \
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
     xserver-xorg-video-dummy \
     xfce4 desktop-base \
     x11vnc net-tools


### PR DESCRIPTION
This fixes all package installs failing with "unable to locate package <package>"